### PR TITLE
feat: modernizar CI/CD a Python 3.13 + Node 22 + uv + pnpm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,10 @@ jobs:
         token: '${{ secrets.ACCESS_TOKEN }}'
         fetch-depth: 0
 
-    - name: Set up Python 3.9
-      uses: actions/setup-python@v4
+    - name: Set up Python 3.13
+      uses: actions/setup-python@v5
       with:
-        python-version: 3.9
+        python-version: 3.13
 
     - name: Install dependencies
       run: |

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 env:
   GIT_USER_EMAIL: erick+ci-cd@fondeadora.com
   GIT_USER_NAME: fcard-tech
+  PYTHON_VERSION: "3.13"
 
 jobs:
   bump:
@@ -18,10 +19,10 @@ jobs:
         token: '${{ secrets.ACCESS_TOKEN }}'
         fetch-depth: 0
 
-    - name: Set up Python 3.13
+    - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.13
+        python-version: ${{ env.PYTHON_VERSION }}
 
     - name: Install dependencies
       run: |

--- a/common/install-deps.sh
+++ b/common/install-deps.sh
@@ -1,3 +1,3 @@
 if [ $CACHE_HIT != 'true' ]; then
-    poetry install
+    uv sync
 fi

--- a/common/install-node-deps.sh
+++ b/common/install-node-deps.sh
@@ -1,3 +1,5 @@
 if [ $CACHE_HIT != 'true' ]; then
-    npm ci
+    corepack enable
+    corepack prepare "pnpm@${PNPM_VERSION:-10.4.1}" --activate
+    pnpm install --frozen-lockfile
 fi

--- a/common/python-setup.sh
+++ b/common/python-setup.sh
@@ -3,9 +3,12 @@ for VERSION in "/opt/hostedtoolcache/Python/$PYTHON_VERSION"*; do
     echo "$VERSION/x64/bin" >> $GITHUB_PATH
 done
 
-if [ -f "poetry.lock" ]; then
-    python3 -m pip install --user pipx
-    pipx install poetry==2.1.1
-    pipx inject poetry poetry-dotenv-plugin
-    pipx inject poetry poetry-plugin-export
+if [ -f "uv.lock" ]; then
+    if [ -n "$UV_VERSION" ]; then
+        UV_INSTALLER="https://astral.sh/uv/$UV_VERSION/install.sh"
+    else
+        UV_INSTALLER="https://astral.sh/uv/install.sh"
+    fi
+    curl -LsSf "$UV_INSTALLER" | env UV_INSTALL_DIR="$HOME/.local/bin" sh
+    echo "$HOME/.local/bin" >> $GITHUB_PATH
 fi

--- a/complexity/action.yml
+++ b/complexity/action.yml
@@ -13,12 +13,12 @@ inputs:
   lint_command:
     description: "The command to run the linter"
     required: false
-    default: "poetry run make complexity"
+    default: "uv run make complexity"
 
   python_version:
     description: "Python version to use"
     required: false
-    default: "3.9"
+    default: "3.13"
 
 runs:
   using: "composite"

--- a/lint/action.yml
+++ b/lint/action.yml
@@ -13,12 +13,12 @@ inputs:
   lint_command:
     description: "The command to run the linter"
     required: false
-    default: "poetry run make lint"
+    default: "uv run make lint"
 
   python_version:
     description: "Python version to use"
     required: false
-    default: "3.9"
+    default: "3.13"
 
 runs:
   using: "composite"

--- a/serverless-deploy/action.yml
+++ b/serverless-deploy/action.yml
@@ -36,7 +36,17 @@ inputs:
   python_version:
     description: "Python version to use"
     required: false
-    default: "3.9"
+    default: "3.13"
+
+  node_version:
+    description: "Node version to use"
+    required: false
+    default: "22"
+
+  pnpm_version:
+    description: "pnpm version to activate via corepack"
+    required: false
+    default: "10.4.1"
 
 runs:
   using: "composite"
@@ -53,11 +63,17 @@ runs:
       env:
         ACCESS_TOKEN: ${{ inputs.access_token }}
 
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node_version }}
+
     - name: Install serverless dependencies
       run: ${{ github.action_path }}/../common/install-node-deps.sh
       shell: bash
       env:
         CACHE_HIT: ${{ inputs.cache_hit }}
+        PNPM_VERSION: ${{ inputs.pnpm_version }}
 
     - name: Setup AWS credentials
       env:
@@ -75,7 +91,7 @@ runs:
         echo "region = $AWS_REGION" >> ~/.aws/credentials
       shell: bash
     - name: Deploy to the desired stage
-      run: AWS_SDK_LOAD_CONFIG=1 npx serverless deploy --stage ${{ inputs.stage }} --aws-profile $AWS_PROFILE
+      run: AWS_SDK_LOAD_CONFIG=1 pnpm exec serverless deploy --stage ${{ inputs.stage }} --aws-profile $AWS_PROFILE
       shell: bash
       env:
         AWS_STACK: ${{ inputs.aws-stack }}

--- a/test/action.yml
+++ b/test/action.yml
@@ -13,12 +13,12 @@ inputs:
   test_command:
     description: "The command to run the linter"
     required: false
-    default: "poetry run make test"
+    default: "uv run make test"
 
   python_version:
     description: "Python version to use"
     required: false
-    default: "3.9"
+    default: "3.13"
 
   env_file:
     description: "The path of the .env file"
@@ -46,10 +46,10 @@ runs:
       env:
         CACHE_HIT: ${{ inputs.cache_hit }}
 
-    - name: Install plugins
-      run: poetry plugin add poetry-dotenv-plugin
-      shell: bash
-
     - name: Run the tests
-      run: POETRY_DOTENV_LOCATION=${{inputs.env_file}} ${{ inputs.test_command }}
       shell: bash
+      run: |
+        set -a
+        [ -f "${{ inputs.env_file }}" ] && . "${{ inputs.env_file }}"
+        set +a
+        ${{ inputs.test_command }}


### PR DESCRIPTION
## Contexto

`fcard-ci-tools` es la librería de *composite actions* de CI/CD que consumen los demás repos de Fondeadora (`uses: f-credit/fcard-ci-tools/<action>@<tag>`). Hasta ahora asumía **Python 3.9 + Poetry 2.1.1 + npm**. Este PR la moderniza a **Python 3.13 + Node 22 + uv + pnpm** para mayor velocidad, resolución reproducible y mejor seguridad de supply-chain.

Referencia: skill `engineering/migrate-to-uv-pnpm`.

## Cambios

**Scripts compartidos (`common/`)**
- `python-setup.sh` — instala **uv** en vez de Poetry, detecta `uv.lock`, pin opcional vía `UV_VERSION`.
- `install-deps.sh` — `poetry install` → `uv sync`.
- `install-node-deps.sh` — `npm ci` → `corepack` + `pnpm install --frozen-lockfile` (versión vía `PNPM_VERSION`, default `10.4.1`).

**Composite actions**
- `lint/`, `complexity/` — default `python_version` 3.9 → **3.13**; comando `poetry run` → `uv run`.
- `test/` — 3.13 + `uv run make test`; elimina `poetry plugin add poetry-dotenv-plugin`; la carga de `.env` ahora se hace sourceando `env_file`.
- `serverless-deploy/` — 3.13; nuevos inputs `node_version` (22) y `pnpm_version` (10.4.1); agrega `actions/setup-node@v4`; deploy con `pnpm exec serverless` en vez de `npx`.

**Workflow propio**
- `release.yml` — `setup-python@v4` → `@v5`; versión de Python **parametrizada** en `env.PYTHON_VERSION` (3.13), sin hardcodear.

## Verificación
- `bash -n` en los 3 scripts modificados: OK.
- YAML de actions + workflows parsea sin errores (PyYAML): OK.
- Pendiente: PR de prueba en un repo consumidor ya migrado a uv/pnpm para validar lint/test/complexity y un deploy a `dev` end-to-end.

## ⚠️ Riesgo: corte limpio
Al subir el nuevo tag de estas actions, **cualquier repo consumidor que siga en Poetry/npm romperá**. Coordinar que migren con el skill `migrate-to-uv-pnpm` antes de bumpear la versión.

🤖 Generated with [Claude Code](https://claude.com/claude-code)